### PR TITLE
Simplify install scripts to use prebuilt extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Desktop only: this is a Spicetify extension for the Spotify desktop client on Wi
 
 ### Quick Install (Recommended)
 
-Just run the one-liner for your OS. It handles everything — git clone, npm install, build, and Spicetify config.
+Just run the one-liner for your OS. It downloads the latest built extension and configures Spicetify.
 
 **Windows (PowerShell):**
 ```powershell
@@ -81,7 +81,7 @@ spicetify apply
 
 ## 🔄 Updating
 
-Just run the same install command again — it detects if you already have it and updates in place.
+Just run the same install command again — it downloads the latest build and updates in place.
 
 **Windows:**
 ```powershell
@@ -93,13 +93,8 @@ irm https://raw.githubusercontent.com/Kyzenkms/spicetify-jam/main/install.ps1 | 
 bash <(curl -fsSL https://raw.githubusercontent.com/Kyzenkms/spicetify-jam/main/install.sh)
 ```
 
-Or update manually:
+Or update manually by copying `dist/spicetify-jam.js` into your Spicetify `Extensions` folder, then run:
 ```bash
-cd ~/.spicetify-jam
-git fetch origin
-git reset --hard origin/main
-npm install
-npm run build
 spicetify apply
 ```
 
@@ -141,9 +136,9 @@ spicetify restore apply
 ```
 Then restart Spotify.
 
-### ❌ `npm` or `git` is not recognized
+### ❌ `spicetify` is not recognized
 
-You need **[Node.js](https://nodejs.org/)** and **[Git](https://git-scm.com/downloads)** installed. After installing, **restart your terminal** so the new commands are recognized.
+Install **[Spicetify](https://spicetify.app/)** first. After installing, restart your terminal so the new command is recognized.
 
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,49 +1,55 @@
-$ErrorActionPreference = "Stop"
+﻿$ErrorActionPreference = "Stop"
 
-$REPO = "https://github.com/Kyzenkms/spicetify-jam.git"
-$DIR = "$env:USERPROFILE\.spicetify-jam"
+$ExtensionName = "spicetify-jam.js"
+$ExtensionUrl = "https://raw.githubusercontent.com/Kyzenkms/spicetify-jam/main/dist/$ExtensionName"
 
 Write-Host "🎵 Installing Spicetify Jam..." -ForegroundColor Green
 
-# Check for git
-if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-    Write-Host "❌ git not found. Install git first: https://git-scm.com/downloads" -ForegroundColor Red
-    exit 1
-}
-
-# Check for npm
-if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
-    Write-Host "❌ npm not found. Install Node.js first: https://nodejs.org/" -ForegroundColor Red
-    exit 1
-}
-
-# Check for spicetify
 if (-not (Get-Command spicetify -ErrorAction SilentlyContinue)) {
     Write-Host "❌ spicetify not found. Install it first: https://spicetify.app/" -ForegroundColor Red
     exit 1
 }
 
-# Clone or update
-if (Test-Path $DIR) {
-    Write-Host "📁 Folder exists, updating..." -ForegroundColor Yellow
-    Set-Location $DIR
-    git fetch origin
-    git reset --hard origin/main
-} else {
-    Write-Host "📥 Cloning repo..." -ForegroundColor Yellow
-    git clone $REPO $DIR
-    Set-Location $DIR
+function Invoke-Spicetify {
+    param([Parameter(Mandatory = $true)][string[]] $Arguments)
+
+    & spicetify @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "spicetify $($Arguments -join ' ') failed."
+    }
 }
 
-Write-Host "📦 Installing dependencies..." -ForegroundColor Yellow
-npm install --silent
+$UserDataPath = (& spicetify path userdata 2>$null | Select-Object -First 1)
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($UserDataPath)) {
+    $UserDataPath = Join-Path $env:APPDATA "spicetify"
+}
 
-Write-Host "🔨 Building..." -ForegroundColor Yellow
-npm run build
+$ExtensionsDir = Join-Path $UserDataPath.Trim() "Extensions"
+$ExtensionPath = Join-Path $ExtensionsDir $ExtensionName
+
+Write-Host "📁 Preparing Extensions folder..." -ForegroundColor Yellow
+New-Item -ItemType Directory -Force -Path $ExtensionsDir | Out-Null
+
+Write-Host "📥 Downloading latest build..." -ForegroundColor Yellow
+Invoke-WebRequest -Uri $ExtensionUrl -UseBasicParsing -OutFile $ExtensionPath
+
+if (-not (Test-Path -LiteralPath $ExtensionPath) -or (Get-Item -LiteralPath $ExtensionPath).Length -eq 0) {
+    throw "Downloaded extension is empty: $ExtensionPath"
+}
 
 Write-Host "⚙️ Configuring Spicetify..." -ForegroundColor Yellow
-spicetify config extensions spicetify-jam.js
-spicetify apply
+$ConfigOutput = & spicetify config extensions 2>$null
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to read Spicetify extensions config."
+}
+
+$ConfiguredExtensions = ($ConfigOutput -join "`n") -split "\r?\n|\|" | ForEach-Object { $_.Trim() }
+
+if ($ConfiguredExtensions -notcontains $ExtensionName) {
+    Invoke-Spicetify @("config", "extensions", $ExtensionName)
+}
+
+Invoke-Spicetify @("apply")
 
 Write-Host ""
 Write-Host "✅ Done! Restart Spotify to use Spicetify Jam." -ForegroundColor Green

--- a/install.sh
+++ b/install.sh
@@ -1,49 +1,49 @@
 #!/usr/bin/env bash
 set -e
 
-REPO="https://github.com/Kyzenkms/spicetify-jam.git"
-DIR="$HOME/.spicetify-jam"
+EXTENSION_NAME="spicetify-jam.js"
+EXTENSION_URL="https://raw.githubusercontent.com/Kyzenkms/spicetify-jam/main/dist/${EXTENSION_NAME}"
 
 echo "🎵 Installing Spicetify Jam..."
 
-# Check for git
-if ! command -v git &>/dev/null; then
-  echo "❌ git not found. Install git first: https://git-scm.com/downloads"
-  exit 1
-fi
-
-# Check for node/npm
-if ! command -v npm &>/dev/null; then
-  echo "❌ npm not found. Install Node.js first: https://nodejs.org/"
-  exit 1
-fi
-
-# Check for spicetify
 if ! command -v spicetify &>/dev/null; then
   echo "❌ spicetify not found. Install it first: https://spicetify.app/"
   exit 1
 fi
 
-# Clone or update
-if [ -d "$DIR" ]; then
-  echo "📁 Folder exists, updating..."
-  cd "$DIR"
-  git fetch origin
-  git reset --hard origin/main
-else
-  echo "📥 Cloning repo..."
-  git clone "$REPO" "$DIR"
-  cd "$DIR"
+SPICETIFY_DATA_DIR="$(spicetify path userdata 2>/dev/null || true)"
+if [ -z "$SPICETIFY_DATA_DIR" ]; then
+  SPICETIFY_DATA_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/spicetify"
 fi
 
-echo "📦 Installing dependencies..."
-npm install --silent
+EXTENSIONS_DIR="${SPICETIFY_DATA_DIR}/Extensions"
+EXTENSION_PATH="${EXTENSIONS_DIR}/${EXTENSION_NAME}"
 
-echo "🔨 Building..."
-npm run build
+echo "📁 Preparing Extensions folder..."
+mkdir -p "$EXTENSIONS_DIR"
+
+echo "📥 Downloading latest build..."
+if command -v curl &>/dev/null; then
+  curl -fsSL "$EXTENSION_URL" -o "$EXTENSION_PATH"
+elif command -v wget &>/dev/null; then
+  wget -q "$EXTENSION_URL" -O "$EXTENSION_PATH"
+else
+  echo "❌ curl or wget is required to download the extension."
+  exit 1
+fi
+
+if [ ! -s "$EXTENSION_PATH" ]; then
+  echo "❌ Downloaded extension is empty: $EXTENSION_PATH"
+  exit 1
+fi
 
 echo "⚙️ Configuring Spicetify..."
-spicetify config extensions spicetify-jam.js
+CURRENT_EXTENSIONS="$(spicetify config extensions)"
+
+if ! printf '%s\n' "$CURRENT_EXTENSIONS" | tr '|' '\n' | grep -Fxq "$EXTENSION_NAME"; then
+  spicetify config extensions "$EXTENSION_NAME"
+fi
+
 spicetify apply
 
 echo ""


### PR DESCRIPTION
## Summary
- download the prebuilt `dist/spicetify-jam.js` in the install scripts instead of requiring Git and Node/npm
- copy the extension into Spicetify's Extensions folder and avoid duplicate config entries
- update README install/update docs to match the new flow

## Validation
- parsed `install.ps1` with PowerShell parser
- checked install scripts no longer call git/npm
- verified the raw prebuilt extension URL returns 200
- ran a mocked PowerShell installer flow locally